### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - "2.7"
+
+before_install:
+  - wget http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
+  - export DEVKITPRO=/home/travis/devkitPro
+  - export DEVKITARM=${DEVKITPRO}/devkitARM
+  - export PATH=$PATH:$DEVKITARM/bin
+
+install:
+  - sudo perl devkitARMupdate.pl
+
+script:
+  - python exp.py


### PR DESCRIPTION
Automatically builds soundhax.m4a on every commit and reports success or fail.  Doesn't upload soundhax.m4a but that can be done.