### PR TITLE
soundhax does work on 9.0J

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ of the firmware for which the sound app is available.
 | Version | N3DS | O3DS/2DS |
 | --- | --- | --- |
 | US 9.0-11.2 | ✓ | ✓ |
-| JPN 10.6-11.2 | ✓ | ✓ |
+| JPN 9.0-11.2 | ✓ | ✓ |
 | EUR 9.0-11.2 | ✓ | ✓ |
 | KOR ?-11.2 | ✗ | ✗ |
 | CHN ?-11.2 | ✗ | ✗ |


### PR DESCRIPTION
the 3DS Sound application was last updated 7.0. only the manual was updated for JPN in 10.6. tested on 9.2.0-20J